### PR TITLE
fix Saw deleting items

### DIFF
--- a/src/main/java/com/simibubi/create/content/processing/recipe/ProcessingInventory.java
+++ b/src/main/java/com/simibubi/create/content/processing/recipe/ProcessingInventory.java
@@ -82,7 +82,7 @@ public class ProcessingInventory extends ItemStackHandlerContainer {
 	}
 
 	@Override
-	public boolean isItemValid(int slot, ItemVariant resource) {
+	public boolean isItemValid(int slot, ItemVariant resource, int count) {
 		return slot == 0 && isEmpty();
 	}
 


### PR DESCRIPTION
RE: https://github.com/Fabricators-of-Create/Porting-Lib/commit/f2b05e102427c0d59a0f35f47fade284d3987211

After the change linked above, the Saw (with bulk processing disabled) has some very weird interactions with Belts, Mechanical Arms and dropped item stacks.